### PR TITLE
[PATCH] [engg]: fix workflow parse error so AI auto-reply can actually run

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -472,8 +472,6 @@ jobs:
   backfill:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    env:
-      TARGET_FOR_AI_TRIAGE_LABEL: ${{ env.TARGET_FOR_AI_TRIAGE_LABEL }}
     steps:
       - name: Label matching issues
         uses: actions/github-script@v7


### PR DESCRIPTION
Fixes the YAML parse error blocking **every** run of `.github/workflows/ai-issues-auto-reply.yml` on the fork:

```
Unrecognized named-value: 'env'.
env.TARGET_FOR_AI_TRIAGE_LABEL
```

### Root cause
The `backfill` job had a job-level `env:` block that self-referenced a workflow-level env:

```yaml
  backfill:
    env:
      TARGET_FOR_AI_TRIAGE_LABEL: ${{ env.TARGET_FOR_AI_TRIAGE_LABEL }}   # ❌ self-reference
```

GitHub Actions does not evaluate `env.*` inside a job-level `env` block against the workflow-level `env` scope — it only sees the job's own env being constructed, so the reference fails to parse and the entire workflow is rejected.

### Why issue #4 never fired the AI
When GitHub can't parse a workflow file, it silently skips future events for that workflow (the `push` runs show 0-duration failures in the Actions tab). That's why `issues.opened` on #4 never produced a workflow run.

### Fix
The job-level block was redundant anyway — the `github-script` step's own `env:` already correctly references the workflow-level env. Remove the job-level block entirely.

### To test after this merges
1. Close and reopen issue #4 (or open a new issue) to re-fire `issues.opened`.
2. Check Actions tab — a run should now succeed with an AI reply posted.

Same fix already landed on the origin PR branch (`kasong/ai-autoreply-ping-stop-copilot`, commit 403d1b29f) so PR #2964 on AzureAD is good too.