### PR TITLE
[PATCH] [engg]: retry Models API on 5xx so transient errors don't abort the reply

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -341,8 +341,12 @@ jobs:
                       --arg user "$USER_PROMPT" \
                 '{model:$m, messages:[{role:"system",content:$sys},{role:"user",content:$user}]}')
 
-          # Call GitHub Models Chat Completions API (retry once on 429)
-          MAX_ATTEMPTS=2
+          # Call GitHub Models Chat Completions API.
+          # Retry on:
+          #   - 429 (rate limit) — honor Retry-After if present
+          #   - 5xx (transient server errors from the Models backend)
+          # Backoff: Retry-After if present, else exponential 10s * attempt, capped 5–60s.
+          MAX_ATTEMPTS=3
           for (( attempt=1; attempt<=MAX_ATTEMPTS; attempt++ )); do
             HTTP_CODE=$(curl -sSL -X POST -w "%{http_code}" -o response.json -D headers.txt \
               -H "Accept: application/vnd.github+json" \
@@ -352,20 +356,27 @@ jobs:
               https://models.github.ai/inference/chat/completions \
               -d "$REQ")
 
-            if [[ "$HTTP_CODE" != "429" ]] || [[ $attempt -eq $MAX_ATTEMPTS ]]; then
+            # Retry only on 429 or 5xx; break on success (2xx) or client error (4xx other than 429).
+            RETRY=0
+            if [[ "$HTTP_CODE" == "429" ]] || [[ "$HTTP_CODE" -ge 500 && "$HTTP_CODE" -lt 600 ]]; then
+              RETRY=1
+            fi
+            if [[ $RETRY -eq 0 ]] || [[ $attempt -eq $MAX_ATTEMPTS ]]; then
               break
             fi
 
             RETRY_AFTER=$(grep -i '^retry-after:' headers.txt | tr -dc '0-9')
-            WAIT=${RETRY_AFTER:-30}
+            DEFAULT_WAIT=$(( 10 * attempt ))
+            WAIT=${RETRY_AFTER:-$DEFAULT_WAIT}
             (( WAIT > 60 )) && WAIT=60
-            echo "Rate limited (429). Retrying in ${WAIT}s (attempt ${attempt}/${MAX_ATTEMPTS})..."
+            (( WAIT < 5  )) && WAIT=5
+            echo "HTTP ${HTTP_CODE} from Models API. Retrying in ${WAIT}s (attempt ${attempt}/${MAX_ATTEMPTS}, model=${GH_MODELS_MODEL})..."
             sleep "$WAIT"
           done
           rm -f headers.txt
 
           if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
-            echo "::error::API request failed with status $HTTP_CODE"
+            echo "::error::Models API request failed with status $HTTP_CODE after ${MAX_ATTEMPTS} attempt(s) using model '${GH_MODELS_MODEL}'. If this persists, try a different model (e.g. openai/gpt-4o-mini) by changing MODELS_MODEL in the workflow env."
             cat response.json
             exit 1
           fi

--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -345,7 +345,7 @@ jobs:
           # Retry on:
           #   - 429 (rate limit) — honor Retry-After if present
           #   - 5xx (transient server errors from the Models backend)
-          # Backoff: Retry-After if present, else exponential 10s * attempt, capped 5–60s.
+          # Backoff: Retry-After if present, else exponential (10s, 20s, 40s, …), capped 5–60s.
           MAX_ATTEMPTS=3
           for (( attempt=1; attempt<=MAX_ATTEMPTS; attempt++ )); do
             HTTP_CODE=$(curl -sSL -X POST -w "%{http_code}" -o response.json -D headers.txt \
@@ -366,7 +366,7 @@ jobs:
             fi
 
             RETRY_AFTER=$(grep -i '^retry-after:' headers.txt | tr -dc '0-9')
-            DEFAULT_WAIT=$(( 10 * attempt ))
+            DEFAULT_WAIT=$(( 10 * (1 << (attempt - 1)) ))
             WAIT=${RETRY_AFTER:-$DEFAULT_WAIT}
             (( WAIT > 60 )) && WAIT=60
             (( WAIT < 5  )) && WAIT=5


### PR DESCRIPTION
Fixes the GitHub Models 500 that aborted the AI reply on issue #6:

```
API request failed with status 500
{
  "error": {
    "message": "The server had an error while processing your request. Sorry about that!",
    "type": "server_error"
  }
}
```

### Root cause
The previous retry loop only handled 429 (rate limit), not 5xx (transient server error). One 500 from the Models backend was enough to fail the entire workflow run.

### Changes
- `MAX_ATTEMPTS=3` (was 2).
- Retry on **429 or 5xx**. Honor `Retry-After` when present; otherwise exponential backoff `10s * attempt`, clamped to [5, 60] seconds.
- On final failure, log the model name and suggest trying `openai/gpt-4o-mini` as an alternative. Useful when the configured model isn't in the fork/repo's Models plan.

### To test after merge
1. Close and reopen issue #6 (or open a new issue).
2. Watch the Actions tab — if the Models API is healthy, you should get an AI reply. If it returns 5xx, the retry will kick in (you'll see "HTTP 500 from Models API. Retrying in Xs…" in the log).

Same fix applied to the origin PR branch (`kasong/ai-autoreply-ping-stop-copilot`, commit `1c3e138b3`).