### PR TITLE
[PATCH] [engg]: add fallback model when primary is unavailable on this plan

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -298,6 +298,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_MODELS_MODEL: ${{ env.MODELS_MODEL }}
+          GH_MODELS_FALLBACK_MODEL: "openai/gpt-4o-mini"
           MODE: ${{ steps.gate.outputs.mode }}
           ISSUE_TITLE_JSON: ${{ toJSON(github.event.issue.title) }}
           ISSUE_BODY_JSON: ${{ toJSON(github.event.issue.body || '') }}
@@ -336,10 +337,14 @@ jobs:
             USER_PROMPT="$(printf 'New issue at: %s \nTitle: %s \n\nBody:\n%s' "$ISSUE_URL" "$ISSUE_TITLE" "$ISSUE_BODY")"
           fi
 
-          REQ=$(jq -n --arg m "$GH_MODELS_MODEL" \
+          # Build the request body. Factored into a function so we can rebuild
+          # with a different model for the fallback retry below.
+          build_req () { jq -n --arg m "$1" \
                       --arg sys "$SYSTEM_PROMPT" \
                       --arg user "$USER_PROMPT" \
-                '{model:$m, messages:[{role:"system",content:$sys},{role:"user",content:$user}]}')
+                '{model:$m, messages:[{role:"system",content:$sys},{role:"user",content:$user}]}'; }
+
+          REQ=$(build_req "$GH_MODELS_MODEL")
 
           # Call GitHub Models Chat Completions API.
           # Retry on:
@@ -376,9 +381,37 @@ jobs:
           rm -f headers.txt
 
           if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
-            echo "::error::Models API request failed with status $HTTP_CODE after ${MAX_ATTEMPTS} attempt(s) using model '${GH_MODELS_MODEL}'. If this persists, try a different model (e.g. openai/gpt-4o-mini) by changing MODELS_MODEL in the workflow env."
-            cat response.json
-            exit 1
+            # One-shot fallback to a known-good model for common 4xx model/
+            # entitlement failures (e.g., the configured model is not available
+            # on this repo's GitHub Models plan). Only fires when a fallback
+            # model is configured AND it differs from the primary.
+            FALLBACK_USED=""
+            if [[ -n "${GH_MODELS_FALLBACK_MODEL:-}" && "${GH_MODELS_FALLBACK_MODEL}" != "${GH_MODELS_MODEL}" ]]; then
+              echo "Primary model '${GH_MODELS_MODEL}' failed (HTTP ${HTTP_CODE}). Retrying once with fallback model='${GH_MODELS_FALLBACK_MODEL}'..."
+              REQ=$(build_req "$GH_MODELS_FALLBACK_MODEL")
+              HTTP_CODE=$(curl -sSL -X POST -w "%{http_code}" -o response.json \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -H "Content-Type: application/json" \
+                https://models.github.ai/inference/chat/completions \
+                -d "$REQ")
+              FALLBACK_USED="${GH_MODELS_FALLBACK_MODEL}"
+            fi
+
+            # If the fallback also failed (or no fallback configured), bail.
+            if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+              if [[ -n "$FALLBACK_USED" ]]; then
+                echo "::error::Models API request failed with status $HTTP_CODE on both primary model '${GH_MODELS_MODEL}' and fallback model '${FALLBACK_USED}'. Check that at least one of these models is available on this repository's GitHub Models plan."
+              else
+                echo "::error::Models API request failed with status $HTTP_CODE after ${MAX_ATTEMPTS} attempt(s) using model '${GH_MODELS_MODEL}'. If this persists, try a different model (e.g. openai/gpt-4o-mini) by changing MODELS_MODEL in the workflow env."
+              fi
+              cat response.json
+              exit 1
+            fi
+
+            # Fallback succeeded — continue with response.json.
+            echo "Fallback model '${FALLBACK_USED}' succeeded with HTTP ${HTTP_CODE}."
           fi
 
           # Check for JSON error field


### PR DESCRIPTION
Fixes the silent-exit-1 observed on runs 24907489856 and 24906828041.

The primary model `openai/gpt-5` isn't entitled on this fork's GitHub Models plan, so the Models backend returns a 4xx that `set -e` + `$(curl …)` propagates as a silent script abort (the error output is redirected to `response.json` which never gets printed before the shell exits).

### Fix
- Factor the request body into a `build_req` function so we can regenerate it with a different model.
- New env var `GH_MODELS_FALLBACK_MODEL` (default `openai/gpt-4o-mini` — broadly available on all Models tiers).
- When the primary model fails (after retry exhaustion), make **one additional attempt** with the fallback model.
- If the fallback succeeds, continue with its response instead of failing. If the fallback also fails, log an explicit error naming both models so the plan issue is obvious.
- Fixes a bug in the original patch draft where a successful fallback would still hit `exit 1` because the outer status-check block didn't re-evaluate `HTTP_CODE`.

### To test after merge
1. Open a new issue.
2. Watch the Actions tab — you should see a line like:
   `Primary model 'openai/gpt-5' failed (HTTP 4xx). Retrying once with fallback model='openai/gpt-4o-mini'...`
   followed by `Fallback model 'openai/gpt-4o-mini' succeeded with HTTP 200.`
3. An AI reply should appear on the issue within ~30s.

### Turning the fallback off
Set `GH_MODELS_FALLBACK_MODEL: ""` in the workflow env. Behavior reverts to fail-fast on primary failure.

Same fix on origin PR branch `kasong/ai-autoreply-ping-stop-copilot` (commit `0fc9698a9`).