### PR TITLE
[PATCH] [engg]: survive transport failures and switch primary model to gpt-4o-mini

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -36,7 +36,9 @@ env:
   STOP_COPILOT_PHRASE: "STOP-COPILOT"        # canonical opt-out phrase shown in docs/acks; natural variants are also matched
   OPT_OUT_LABEL: "no-ai"                      # label added when opt-out is triggered (must be present in BLOCK_LABELS to suppress future replies)
   DRY_RUN: "false"
-  MODELS_MODEL: "openai/gpt-5"
+  # Model defaults: fork uses gpt-4o-mini (broadly available on all GitHub Models plans).
+  # Origin (AzureAD) uses openai/gpt-5 — do NOT copy this fork-specific change upstream.
+  MODELS_MODEL: "openai/gpt-4o-mini"
 
 jobs:
   ai_autoreply:
@@ -194,10 +196,9 @@ jobs:
             if (issue.pull_request) { core.setOutput('should','false'); return; }
 
             // FORK-TEST ONLY: maintainer-author restriction disabled so the
-            // fork owner can self-test by opening new issues. DO NOT merge this
-            // change back to origin (AzureAD/microsoft-authentication-library-
-            // for-objc) — maintainer-authored issues should not auto-reply on
-            // the production repo.
+            // fork owner can self-test by opening new issues. DO NOT merge
+            // this change back to origin (AzureAD/...) — maintainer-authored
+            // issues should not auto-reply on the production repo.
             // const assoc = issue.author_association || 'NONE';
             // if (['OWNER','MEMBER','COLLABORATOR'].includes(assoc)) {
             //   core.setOutput('should', 'false'); return;
@@ -346,36 +347,71 @@ jobs:
 
           REQ=$(build_req "$GH_MODELS_MODEL")
 
-          # Call GitHub Models Chat Completions API.
-          # Retry on:
-          #   - 429 (rate limit) — honor Retry-After if present
-          #   - 5xx (transient server errors from the Models backend)
-          # Backoff: Retry-After if present, else exponential (10s, 20s, 40s, …), capped 5–60s.
-          MAX_ATTEMPTS=3
-          for (( attempt=1; attempt<=MAX_ATTEMPTS; attempt++ )); do
-            HTTP_CODE=$(curl -sSL -X POST -w "%{http_code}" -o response.json -D headers.txt \
+          # Helper: invoke the Models API and set HTTP_CODE, tolerating
+          # transport-level failures (DNS, TLS, timeout, reset, …). Previously
+          # a non-zero curl exit would propagate through `HTTP_CODE=$(curl …)`
+          # and `set -e` would abort the whole script silently — no echo, no
+          # retry, no fallback, just exit 1 after some seconds of nothing.
+          # Now:
+          #   - `set +e` around the curl so failures don't kill the shell.
+          #   - stderr captured to a temp file and surfaced.
+          #   - --max-time bounds the request.
+          #   - HTTP_CODE set to "000" on transport failure, which is treated
+          #     as retryable below.
+          call_models_api () {
+            local body="$1"
+            local label="$2"
+            local stderr_file
+            stderr_file="$(mktemp)"
+            echo "→ Calling Models API (${label})..."
+            local curl_exit=0
+            set +e
+            HTTP_CODE=$(curl -sSL -X POST --max-time 120 -w "%{http_code}" \
+              -o response.json -D headers.txt \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               -H "Content-Type: application/json" \
               https://models.github.ai/inference/chat/completions \
-              -d "$REQ")
+              -d "$body" 2>"$stderr_file")
+            curl_exit=$?
+            set -e
+            if [[ $curl_exit -ne 0 ]]; then
+              echo "← curl failed (exit ${curl_exit}) for ${label}. stderr:"
+              sed 's/^/    /' "$stderr_file" || true
+              HTTP_CODE="000"
+            else
+              echo "← Models API responded HTTP ${HTTP_CODE} (${label})"
+            fi
+            rm -f "$stderr_file"
+          }
 
-            # Retry only on 429 or 5xx; break on success (2xx) or client error (4xx other than 429).
+          # Primary model retry loop.
+          # Retry on:
+          #   - 429 (rate limit) — honor Retry-After if present
+          #   - 5xx (transient server errors from the Models backend)
+          #   - 000 (transport failure — no HTTP response)
+          # Backoff: Retry-After if present, else exponential (10s, 20s, 40s), capped 5–60s.
+          MAX_ATTEMPTS=3
+          for (( attempt=1; attempt<=MAX_ATTEMPTS; attempt++ )); do
+            call_models_api "$REQ" "primary, attempt ${attempt}/${MAX_ATTEMPTS}, model=${GH_MODELS_MODEL}"
+
             RETRY=0
-            if [[ "$HTTP_CODE" == "429" ]] || [[ "$HTTP_CODE" -ge 500 && "$HTTP_CODE" -lt 600 ]]; then
+            if [[ "$HTTP_CODE" == "429" ]] \
+               || [[ "$HTTP_CODE" == "000" ]] \
+               || [[ "$HTTP_CODE" -ge 500 && "$HTTP_CODE" -lt 600 ]]; then
               RETRY=1
             fi
             if [[ $RETRY -eq 0 ]] || [[ $attempt -eq $MAX_ATTEMPTS ]]; then
               break
             fi
 
-            RETRY_AFTER=$(grep -i '^retry-after:' headers.txt | tr -dc '0-9')
+            RETRY_AFTER=$(grep -i '^retry-after:' headers.txt 2>/dev/null | tr -dc '0-9' || true)
             DEFAULT_WAIT=$(( 10 * (1 << (attempt - 1)) ))
             WAIT=${RETRY_AFTER:-$DEFAULT_WAIT}
             (( WAIT > 60 )) && WAIT=60
             (( WAIT < 5  )) && WAIT=5
-            echo "HTTP ${HTTP_CODE} from Models API. Retrying in ${WAIT}s (attempt ${attempt}/${MAX_ATTEMPTS}, model=${GH_MODELS_MODEL})..."
+            echo "Retrying in ${WAIT}s..."
             sleep "$WAIT"
           done
           rm -f headers.txt
@@ -389,13 +425,7 @@ jobs:
             if [[ -n "${GH_MODELS_FALLBACK_MODEL:-}" && "${GH_MODELS_FALLBACK_MODEL}" != "${GH_MODELS_MODEL}" ]]; then
               echo "Primary model '${GH_MODELS_MODEL}' failed (HTTP ${HTTP_CODE}). Retrying once with fallback model='${GH_MODELS_FALLBACK_MODEL}'..."
               REQ=$(build_req "$GH_MODELS_FALLBACK_MODEL")
-              HTTP_CODE=$(curl -sSL -X POST -w "%{http_code}" -o response.json \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer $GH_TOKEN" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                -H "Content-Type: application/json" \
-                https://models.github.ai/inference/chat/completions \
-                -d "$REQ")
+              call_models_api "$REQ" "fallback, model=${GH_MODELS_FALLBACK_MODEL}"
               FALLBACK_USED="${GH_MODELS_FALLBACK_MODEL}"
             fi
 
@@ -406,7 +436,8 @@ jobs:
               else
                 echo "::error::Models API request failed with status $HTTP_CODE after ${MAX_ATTEMPTS} attempt(s) using model '${GH_MODELS_MODEL}'. If this persists, try a different model (e.g. openai/gpt-4o-mini) by changing MODELS_MODEL in the workflow env."
               fi
-              cat response.json
+              echo "Response body (if any):"
+              cat response.json 2>/dev/null || echo "(no response body written)"
               exit 1
             fi
 


### PR DESCRIPTION
Bundles two fixes so the AI auto-reply actually produces a comment on new fork issues.

### 1. Silent-exit-1 root cause: transport-level curl failure

Latest failing run: the log shows ~18s of activity and then just `##[error]Process completed with exit code 1.` — no retry message, no fallback message, no error line, no `cat response.json`.

That pattern is `HTTP_CODE=$(curl …)` exiting non-zero under `set -e`, which kills the shell before any echo runs. The previous fallback patch assumed curl would always succeed and return a 4xx we could branch on.

**Fix:** factor the Models call into a helper that wraps curl in `set +e` / `set -e`, captures stderr to a temp file and surfaces it, adds `--max-time 120`, and sets `HTTP_CODE="000"` on transport failure. `"000"` is treated as retryable in the loop and fallback-eligible in the status check, so transport problems produce visible logs instead of silent aborts.

### 2. Model switch: gpt-5 → gpt-4o-mini (fork-only)

GitHub's remote Copilot noted that `openai/gpt-5` is not in this fork's Models plan, which is why every call from this fork has ended in an error you couldn't see. Switching the primary to `openai/gpt-4o-mini` (broadly available on every Models tier) makes the flow produce replies immediately — no fallback dance needed.

```diff
-  MODELS_MODEL: "openai/gpt-5"
+  # Model defaults: fork uses gpt-4o-mini (broadly available on all GitHub Models plans).
+  # Origin (AzureAD) uses openai/gpt-5 — do NOT copy this fork-specific change upstream.
+  MODELS_MODEL: "openai/gpt-4o-mini"
```

### To test after merge
1. Open a new test issue.
2. Actions log should now show:
   ```
   → Calling Models API (primary, attempt 1/3, model=openai/gpt-4o-mini)...
   ← Models API responded HTTP 200 (primary, attempt 1/3, model=openai/gpt-4o-mini)
   ```
   and the AI reply should appear on the issue within ~30s.
3. If you still see silent exits, the helper now captures curl's stderr and prints it (look for `← curl failed (exit N) for …` with the stderr indented below).

The resilience commit (part 1) has been pushed to origin PR branch `kasong/ai-autoreply-ping-stop-copilot` (origin commit `d5dc2fbae`). Origin keeps `openai/gpt-5` as its default — the model change in part 2 is fork-only.