### PR TITLE
[PATCH] [engg]: pass AI body via env to avoid SyntaxError in Post reply

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -470,9 +470,17 @@ jobs:
           MODE: ${{ steps.gate.outputs.mode }}
           PING_COPILOT_PHRASE: ${{ env.PING_COPILOT_PHRASE }}
           STOP_COPILOT_PHRASE: ${{ env.STOP_COPILOT_PHRASE }}
+          # Pass the AI body via env (not inline ${{ }} interpolation) so
+          # backticks, ${...}, and other JS-significant characters in the AI
+          # output can't break the script source. The earlier inline form
+          # crashed with SyntaxError: Unexpected identifier 'MSAL...' when
+          # the AI reply contained ``MSALInteractiveTokenParameters`` markdown
+          # code spans — the backticks ended the JS template literal and the
+          # identifiers inside became invalid JS.
+          AI_BODY: ${{ steps.ai.outputs.text }}
         with:
           script: |
-            const body = `${{ steps.ai.outputs.text }}` || '';
+            const body = process.env.AI_BODY || '';
             const mode = (process.env.MODE || 'initial').trim();
             const pingPhrase = (process.env.PING_COPILOT_PHRASE || 'PING-COPILOT:').trim();
             const stopPhrase = (process.env.STOP_COPILOT_PHRASE || 'STOP-COPILOT').trim();


### PR DESCRIPTION
Fixes the PING-COPILOT failure on run 24908355599 where the `Post reply` step crashed with:

```
SyntaxError: Unexpected identifier 'MSALInteractiveTokenParameters'
    at new AsyncFunction (<anonymous>)
```

### Root cause
The AI reply contained a markdown inline code span like ````MSALInteractiveTokenParameters````, and the step was embedding the AI text into a JavaScript template literal via GitHub Actions' `${{ }}` inline substitution:

```yaml
script: |
  const body = `${{ steps.ai.outputs.text }}` || '';
```

GitHub Actions does **string-level** substitution of `${{ }}` into the script source before Node parses it. The backticks inside the AI's markdown code span terminated the JS template literal early, and the class names inside became invalid bare identifiers.

### Fix
Pass the AI body through the step's `env:` block (which becomes a proper environment variable, never touching the script source) and read it with `process.env.AI_BODY`:

```diff
   env:
     ...
+    AI_BODY: ${{ steps.ai.outputs.text }}
   with:
     script: |
-      const body = `${{ steps.ai.outputs.text }}` || '';
+      const body = process.env.AI_BODY || '';
```

### To test after merge
1. Post a follow-up comment on any open issue: `PING-COPILOT: what are the main MSAL APIs?`
2. The AI reply with markdown-wrapped class names like ``MSALPublicClientApplication`` / ``MSALInteractiveTokenParameters`` etc. should now be posted successfully — no SyntaxError.

Same fix landed on origin PR branch `kasong/ai-autoreply-ping-stop-copilot` (origin commit `a9eaa1a23`).