### PR TITLE
[PATCH] [engg]: upgrade checkout/github-script to Node-24 versions

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -49,11 +49,11 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Decide whether to reply
         id: gate
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PING_COPILOT_PHRASE: ${{ env.PING_COPILOT_PHRASE }}
         with:
@@ -236,7 +236,7 @@ jobs:
 
       - name: Apply opt-out (disable future Copilot replies on this issue)
         if: steps.gate.outputs.stop_detected == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           OPT_OUT_LABEL: ${{ env.OPT_OUT_LABEL }}
           STOP_COPILOT_PHRASE: ${{ env.STOP_COPILOT_PHRASE }}
@@ -463,7 +463,7 @@ jobs:
 
       - name: Post reply
         if: steps.gate.outputs.should == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DRY_RUN: ${{ env.DRY_RUN }}
           TARGET_FOR_AI_TRIAGE_LABEL: ${{ env.TARGET_FOR_AI_TRIAGE_LABEL }}
@@ -557,7 +557,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label matching issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SEARCH_QUERY: ${{ inputs.search_query }}
           MAX_ISSUES:   ${{ inputs.max_issues }}


### PR DESCRIPTION
Eliminates the Node.js 20 deprecation warning that appears on every run:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20
and may not work as expected: actions/checkout@v4, actions/github-script@v7.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
```

### Changes
- `actions/checkout` **v4 → v6** — verified `runs.using: node24` in `action.yml` at tag `v6`. v6.0.2 released 2026-01-09.
- `actions/github-script` **v7 → v8** — verified `runs.using: node24` in `action.yml` at tag `v8`. Released 2025-09-04, stable for 7 months.

v9 of github-script also exists (released 2026-04-09 — only ~2 weeks ago) but is too fresh to pick up in a workflow that's been seeing issues; v8 is the safer choice.

### Compatibility
Both major bumps are transparent for this workflow's usage:
- `checkout` uses default args.
- `github-script` uses standard `github`, `context`, `core`, `process.env`, and `require`.

### To test after merge
Re-trigger the workflow (open a new issue or post a PING-COPILOT). The deprecation warning should be gone from the annotations.

Same upgrade applied to origin PR branch `kasong/ai-autoreply-ping-stop-copilot` (commit `bae6bb24c`).