### PR TITLE
[PATCH] [engg]: inline repo headers + API cheatsheet as AI prompt reference (Tier 2)

### DIFF
--- a/.github/ai-prompts/reference-files.txt
+++ b/.github/ai-prompts/reference-files.txt
@@ -1,0 +1,41 @@
+# Files to inline as reference material into the AI auto-reply prompt.
+# One path per line, relative to the repo root. Blank lines and lines
+# starting with # are ignored. Missing files are skipped with a warning.
+#
+# Keep this list focused on the most-cited public surfaces — every byte
+# added here increases every Models API request payload. A soft cap
+# (MAX_REFERENCE_BYTES in the workflow) trims anything over budget.
+
+# Canonical MSAL API usage examples
+.clinerules/03-MSAL-API-usage.md
+
+# Main entry point + single-account (shared device) category
+MSAL/src/public/MSALPublicClientApplication.h
+MSAL/src/public/MSALPublicClientApplication+SingleAccount.h
+
+# Parameter builders (interactive / silent / signout / base)
+MSAL/src/public/MSALInteractiveTokenParameters.h
+MSAL/src/public/MSALSilentTokenParameters.h
+MSAL/src/public/MSALSignoutParameters.h
+MSAL/src/public/MSALTokenParameters.h
+MSAL/src/public/MSALParameters.h
+MSAL/src/public/MSALWebviewParameters.h
+
+# Results, accounts, claims
+MSAL/src/public/MSALResult.h
+MSAL/src/public/MSALAccount.h
+MSAL/src/public/MSALAccountId.h
+MSAL/src/public/MSALClaimsRequest.h
+
+# Errors (large but heavily cited in support questions)
+MSAL/src/public/MSALError.h
+
+# Device info (for shared device mode detection)
+MSAL/src/public/MSALDeviceInformation.h
+MSAL/src/public/MSALDefinitions.h
+
+# Authority types
+MSAL/src/public/MSALAuthority.h
+MSAL/src/public/MSALAADAuthority.h
+MSAL/src/public/MSALB2CAuthority.h
+MSAL/src/public/MSALCIAMAuthority.h

--- a/.github/ai-prompts/system-common.md
+++ b/.github/ai-prompts/system-common.md
@@ -37,6 +37,10 @@ Results & errors
 - MSALResult: accessToken, account, tenantProfile, scopes, expiresOn.
 - Errors live in MSALErrorDomain. Common codes: MSALErrorInteractionRequired, MSALErrorServerDeclinedScopes, MSALErrorUserCanceled, MSALErrorBrokerResponseNotReceived. Full list in MSALError.h.
 
+## Reference material in the user message
+
+The user message below contains a `=== REFERENCE MATERIAL ===` section with extracts from this repo: the MSAL API usage cheatsheet and the most-cited public headers. **Prefer this material over your training data when they disagree** — it reflects the current public API. Quote specific method signatures, parameter names, and flag defaults directly from the reference extracts whenever possible.
+
 ## Response quality requirements — your answer MUST
 
 1. Ground every technical claim in a specific MSAL public API, header, or flag. Name them explicitly (e.g., "MSALSignoutParameters.wipeAccount").

--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -318,12 +318,65 @@ jobs:
           # per-mode task instructions.
           COMMON_CONTEXT="$(cat .github/ai-prompts/system-common.md)"
 
+          # ---- Reference material (Tier 2 grounding) ----
+          # Assemble a block of repo extracts the model can quote from:
+          # the MSAL-API-usage cheatsheet and the most-cited public headers.
+          # Listed in reference-files.txt so editing the set doesn't require
+          # touching this workflow. Files not present on disk are skipped.
+          # A soft byte cap keeps the user prompt within Models API limits
+          # on every plan we ship (gpt-4o-mini: 128K context).
+          REFERENCE_MANIFEST=".github/ai-prompts/reference-files.txt"
+          REFERENCE_FILE="$(mktemp)"
+          # Soft cap. Models API supports 128K context on gpt-4o-mini; the
+          # full manifest assembles to ~115K and leaves plenty of room for
+          # the system prompt, the user question, and the completion.
+          # Raise if the manifest grows; lower if you need faster/cheaper
+          # replies.
+          MAX_REFERENCE_BYTES=120000
+          {
+            echo "The following are extracts from this repository. When answering, cite specific APIs, parameter names, flag defaults, and file paths from these extracts rather than generic OAuth/OIDC knowledge. If the answer is not covered here, say so."
+            echo ""
+            if [[ -f "$REFERENCE_MANIFEST" ]]; then
+              while IFS= read -r path || [[ -n "$path" ]]; do
+                # Skip blank lines and comments
+                case "$path" in ''|\#*) continue ;; esac
+                if [[ -f "$path" ]]; then
+                  echo "## $path"
+                  echo ""
+                  case "$path" in
+                    *.md) cat "$path" ;;
+                    *)    echo '```objc'; cat "$path"; echo '```' ;;
+                  esac
+                  echo ""
+                else
+                  echo "::warning::Reference file missing from checkout: $path"
+                fi
+              done < "$REFERENCE_MANIFEST"
+            else
+              echo "::warning::Reference manifest $REFERENCE_MANIFEST not found; proceeding without Tier 2 grounding."
+            fi
+          } > "$REFERENCE_FILE"
+
+          REFERENCE_BYTES=$(wc -c < "$REFERENCE_FILE")
+          if (( REFERENCE_BYTES > MAX_REFERENCE_BYTES )); then
+            head -c "$MAX_REFERENCE_BYTES" "$REFERENCE_FILE" > "${REFERENCE_FILE}.trunc"
+            printf '\n\n[reference material truncated at %d bytes — see %s to adjust]\n' "$MAX_REFERENCE_BYTES" "$REFERENCE_MANIFEST" >> "${REFERENCE_FILE}.trunc"
+            mv "${REFERENCE_FILE}.trunc" "$REFERENCE_FILE"
+            echo "Reference material truncated: was ${REFERENCE_BYTES}B, now ${MAX_REFERENCE_BYTES}B."
+          else
+            echo "Reference material assembled: ${REFERENCE_BYTES}B."
+          fi
+          REFERENCE_CONTENT="$(cat "$REFERENCE_FILE")"
+          rm -f "$REFERENCE_FILE"
+
+          # Build the task-specific question body first, then prepend the
+          # reference block. Putting reference BEFORE the question means the
+          # model reads authoritative source material, then the question.
           if [[ "${MODE:-initial}" == "ping_copilot" ]]; then
             TASK_BLOCK="$(cat .github/ai-prompts/system-task-ping-copilot.md)"
             SYSTEM_PROMPT="${COMMON_CONTEXT}${TASK_BLOCK}"
 
-            # Build the user prompt from the payload written by the gate step
-            USER_PROMPT="$(jq -r '
+            QUESTION_BLOCK="$(jq -r '
               "Issue URL: " + .issue.url + "\n" +
               "Title: "     + .issue.title + "\n\n" +
               "Original issue body (by @" + .issue.author + "):\n" + .issue.body + "\n\n" +
@@ -336,6 +389,7 @@ jobs:
               "\n\n--- New PING-COPILOT follow-up from @" + .trigger.author + " ---\n" +
               .trigger.body
             ' prompt_input.json)"
+            USER_PROMPT="$(printf '=== REFERENCE MATERIAL (for grounding) ===\n%s\n\n=== USER QUESTION / THREAD ===\n%s' "$REFERENCE_CONTENT" "$QUESTION_BLOCK")"
           else
             TASK_BLOCK="$(cat .github/ai-prompts/system-task-initial.md)"
             SYSTEM_PROMPT="${COMMON_CONTEXT}${TASK_BLOCK}"
@@ -344,7 +398,8 @@ jobs:
             ISSUE_TITLE="$(jq -r '.' <<< "$ISSUE_TITLE_JSON")"
             ISSUE_BODY="$(jq -r '.'  <<< "$ISSUE_BODY_JSON")"
 
-            USER_PROMPT="$(printf 'New issue at: %s \nTitle: %s \n\nBody:\n%s' "$ISSUE_URL" "$ISSUE_TITLE" "$ISSUE_BODY")"
+            QUESTION_BLOCK="$(printf 'New issue at: %s \nTitle: %s \n\nBody:\n%s' "$ISSUE_URL" "$ISSUE_TITLE" "$ISSUE_BODY")"
+            USER_PROMPT="$(printf '=== REFERENCE MATERIAL (for grounding) ===\n%s\n\n=== NEW ISSUE ===\n%s' "$REFERENCE_CONTENT" "$QUESTION_BLOCK")"
           fi
 
           # Build the request body. Factored into a function so we can rebuild


### PR DESCRIPTION
Tier 2 grounding: give the Models API the literal public API surface so it can quote real method signatures instead of pattern-matching from training data.

### What changes

**New manifest `.github/ai-prompts/reference-files.txt`** — plain-text list of 20 files to inline as reference material. Blank lines and `#` comments are skipped; missing files produce a warning, not a failure.

Included:
- `.clinerules/03-MSAL-API-usage.md` (canonical usage examples)
- `MSALPublicClientApplication.h` + `+SingleAccount` category
- All token/signout parameter builders + base classes + `MSALWebviewParameters.h`
- `MSALResult.h`, `MSALAccount.h`, `MSALAccountId.h`, `MSALClaimsRequest.h`
- `MSALError.h` (large but heavily cited in support questions)
- `MSALDeviceInformation.h`, `MSALDefinitions.h` (shared-device-mode enums)
- Authority types: AAD, B2C, CIAM + base

**Workflow** — the "Generate AI reply" step now:
1. Walks the manifest and `cat`s each file into a temp reference block (`.md` files as-is; `.h` files fenced in ```objc).
2. Applies a soft 120,000-byte cap (full manifest assembles to ~115KB; gpt-4o-mini has a 128K context window — plenty of room).
3. Prepends `=== REFERENCE MATERIAL (for grounding) ===` to the user prompt, followed by `=== USER QUESTION / THREAD ===` (or `=== NEW ISSUE ===`).

**`system-common.md`** adds a "Reference material in the user message" section telling the model to **prefer the extracts over training data when they disagree** and to quote specific method signatures directly.

### Why this helps

Before Tier 2, the model knew *about* MSAL APIs (from the inlined API catalog in `system-common.md`) but didn't have the signatures. With Tier 2 it can literally quote `- (void)signoutWithAccount:(MSALAccount *)account signoutParameters:(MSALSignoutParameters *)signoutParameters completionBlock:...` and describe every flag's default based on the header comment — no guessing.

### To test

Post `PING-COPILOT: walk me through the MSALSilentTokenParameters init path and what happens on MSALErrorInteractionRequired`. The reply should quote the exact initializer from the header, describe the fallback-to-interactive pattern with the real error constant, and reference code-style-correct examples.

### Tuning

- **Add/remove files**: edit `.github/ai-prompts/reference-files.txt` — no YAML edit needed.
- **Change size cap**: `MAX_REFERENCE_BYTES` in the workflow (currently 120000).
- **Disable Tier 2 entirely**: empty the manifest. Workflow falls back to Tier 1 behavior with a single warning.

Same commit (`ef5288ab3`) applied to origin PR branch `kasong/ai-autoreply-ping-stop-copilot`.