### PR TITLE
[PATCH] [engg]: fit AI prompt under GitHub Models 8000-token per-request cap

### DIFF
--- a/.github/ai-prompts/reference-files.txt
+++ b/.github/ai-prompts/reference-files.txt
@@ -2,37 +2,49 @@
 # One path per line, relative to the repo root. Blank lines and lines
 # starting with # are ignored. Missing files are skipped with a warning.
 #
-# Keep this list focused on the most-cited public surfaces — every byte
-# added here increases every Models API request payload. A soft cap
-# (MAX_REFERENCE_BYTES in the workflow) trims anything over budget.
+# BUDGET: GitHub Models caps some free-tier models (gpt-4o-mini) at
+# 8000 tokens per request. With system prompt + question + completion
+# overhead, reference content must fit in ~14 KB (~3500 tokens).
+#
+# Each .h file is stripped of its MIT license block and #import lines
+# before inlining. A per-file cap (MAX_PER_FILE_BYTES, default 4000)
+# and a total cap (MAX_REFERENCE_BYTES, default 14000) apply.
+#
+# Files are included in the order listed below. Anything that doesn't
+# fit under the total cap is truncated from the tail, so the most
+# important files go first.
 
-# Canonical MSAL API usage examples
+# Canonical MSAL API usage examples — highest signal per byte
 .clinerules/03-MSAL-API-usage.md
 
-# Main entry point + single-account (shared device) category
-MSAL/src/public/MSALPublicClientApplication.h
-MSAL/src/public/MSALPublicClientApplication+SingleAccount.h
-
-# Parameter builders (interactive / silent / signout / base)
+# Parameter builders: small, high-value, commonly asked about
+MSAL/src/public/MSALSignoutParameters.h
 MSAL/src/public/MSALInteractiveTokenParameters.h
 MSAL/src/public/MSALSilentTokenParameters.h
-MSAL/src/public/MSALSignoutParameters.h
-MSAL/src/public/MSALTokenParameters.h
-MSAL/src/public/MSALParameters.h
+
+# Shared device mode helpers
+MSAL/src/public/MSALPublicClientApplication+SingleAccount.h
+MSAL/src/public/MSALDeviceInformation.h
+
+# Webview config (interactive flow)
 MSAL/src/public/MSALWebviewParameters.h
 
-# Results, accounts, claims
+# Result type
 MSAL/src/public/MSALResult.h
+
+# --- Below here is aspirational; will likely be truncated on small models ---
+
+# Main entry point (large — would dominate the budget; included last so
+# other high-value files survive the cap).
+MSAL/src/public/MSALPublicClientApplication.h
+
+# Accounts & claims
 MSAL/src/public/MSALAccount.h
-MSAL/src/public/MSALAccountId.h
 MSAL/src/public/MSALClaimsRequest.h
 
-# Errors (large but heavily cited in support questions)
-MSAL/src/public/MSALError.h
-
-# Device info (for shared device mode detection)
-MSAL/src/public/MSALDeviceInformation.h
+# Errors / definitions (device mode enum, prompt types)
 MSAL/src/public/MSALDefinitions.h
+MSAL/src/public/MSALError.h
 
 # Authority types
 MSAL/src/public/MSALAuthority.h

--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -130,12 +130,16 @@ jobs:
               }
 
               // Fetch prior thread for context (exclude the triggering comment itself).
-              // Hard caps keep the resulting prompt within Model API context / size limits
-              // on long-running threads: include only the most recent N comments and
-              // truncate once a total-character budget is exhausted.
-              const MAX_THREAD_COMMENTS    = 20;
-              const MAX_THREAD_CHARS       = 24000;
-              const MAX_COMMENT_BODY_CHARS = 4000;
+              // Hard caps keep the resulting prompt within GitHub Models' per-request
+              // token limit (8000 input tokens on free-tier gpt-4o-mini). Budget:
+              //   system prompt:     ~1500 tokens
+              //   reference block:   ~2000 tokens (MAX_REFERENCE_BYTES=8000 in workflow)
+              //   issue body + trigger + thread: ~3500 tokens combined
+              //   safety:            ~1000 tokens
+              // Aim high on recent context, low on stale tail.
+              const MAX_THREAD_COMMENTS    = 8;
+              const MAX_THREAD_CHARS       = 6000;
+              const MAX_COMMENT_BODY_CHARS = 1500;
 
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: issue.number, per_page: 100
@@ -164,19 +168,24 @@ jobs:
               }
               const thread = limitedThread.reverse();
 
+              // Same token-budget rationale as the thread caps above: each
+              // of these can contribute up to ~1000 tokens to the request.
+              const MAX_ISSUE_BODY_CHARS   = 3000;
+              const MAX_TRIGGER_BODY_CHARS = 3000;
+
               const payload = {
                 mode: 'ping_copilot',
                 issue: {
                   url: issue.html_url,
                   title: issue.title,
-                  body: (issue.body || '').slice(0, 8000),
+                  body: (issue.body || '').slice(0, MAX_ISSUE_BODY_CHARS),
                   author: issue.user?.login || 'unknown'
                 },
                 thread,
                 trigger: {
                   author: comment.user?.login || 'unknown',
                   assoc: comment.author_association || 'NONE',
-                  body: body.slice(0, 8000),
+                  body: body.slice(0, MAX_TRIGGER_BODY_CHARS),
                   url: comment.html_url
                 }
               };
@@ -319,20 +328,40 @@ jobs:
           COMMON_CONTEXT="$(cat .github/ai-prompts/system-common.md)"
 
           # ---- Reference material (Tier 2 grounding) ----
-          # Assemble a block of repo extracts the model can quote from:
-          # the MSAL-API-usage cheatsheet and the most-cited public headers.
+          # Assemble a block of repo extracts the model can quote from.
           # Listed in reference-files.txt so editing the set doesn't require
-          # touching this workflow. Files not present on disk are skipped.
-          # A soft byte cap keeps the user prompt within Models API limits
-          # on every plan we ship (gpt-4o-mini: 128K context).
+          # touching this workflow. Files not present on disk log a warning
+          # and are skipped.
+          #
+          # Budget: GitHub Models free tier caps some models (e.g.,
+          # gpt-4o-mini) at 8000 tokens PER REQUEST. Tokens ≈ bytes/4 for
+          # English/code. We budget roughly:
+          #   system prompt: ~1500 tokens (~6000 bytes)
+          #   reference:     up to MAX_REFERENCE_BYTES (default 14000 = ~3500 tokens)
+          #   question:      up to ~2500 tokens (thread-heavy PING-COPILOT)
+          #   completion:    separate from the 8000 input cap
+          # Per-file boilerplate stripping saves ~1 KB/header (license +
+          # #import lines).
           REFERENCE_MANIFEST=".github/ai-prompts/reference-files.txt"
           REFERENCE_FILE="$(mktemp)"
-          # Soft cap. Models API supports 128K context on gpt-4o-mini; the
-          # full manifest assembles to ~115K and leaves plenty of room for
-          # the system prompt, the user question, and the completion.
-          # Raise if the manifest grows; lower if you need faster/cheaper
-          # replies.
-          MAX_REFERENCE_BYTES=120000
+          MAX_REFERENCE_BYTES="${MAX_REFERENCE_BYTES_OVERRIDE:-8000}"
+          MAX_PER_FILE_BYTES="${MAX_PER_FILE_BYTES_OVERRIDE:-3000}"
+
+          # Strip MIT license block + #import/#pragma lines from an Obj-C
+          # header. The license ends before the first #import / @-directive /
+          # NS_ASSUME_NONNULL_BEGIN. cat -s collapses repeated blank lines.
+          strip_hdr () {
+            awk '
+              BEGIN { skip_header = 1 }
+              skip_header {
+                if (/^#import/ || /^NS_ASSUME_NONNULL_BEGIN/ || /^@/) { skip_header = 0 }
+                else { next }
+              }
+              /^#import/ || /^#pragma/ { next }
+              { print }
+            ' "$1" | cat -s
+          }
+
           {
             echo "The following are extracts from this repository. When answering, cite specific APIs, parameter names, flag defaults, and file paths from these extracts rather than generic OAuth/OIDC knowledge. If the answer is not covered here, say so."
             echo ""
@@ -344,8 +373,14 @@ jobs:
                   echo "## $path"
                   echo ""
                   case "$path" in
-                    *.md) cat "$path" ;;
-                    *)    echo '```objc'; cat "$path"; echo '```' ;;
+                    *.md)
+                      head -c "$MAX_PER_FILE_BYTES" "$path"
+                      ;;
+                    *)
+                      echo '```objc'
+                      strip_hdr "$path" | head -c "$MAX_PER_FILE_BYTES"
+                      echo '```'
+                      ;;
                   esac
                   echo ""
                 else
@@ -362,9 +397,9 @@ jobs:
             head -c "$MAX_REFERENCE_BYTES" "$REFERENCE_FILE" > "${REFERENCE_FILE}.trunc"
             printf '\n\n[reference material truncated at %d bytes — see %s to adjust]\n' "$MAX_REFERENCE_BYTES" "$REFERENCE_MANIFEST" >> "${REFERENCE_FILE}.trunc"
             mv "${REFERENCE_FILE}.trunc" "$REFERENCE_FILE"
-            echo "Reference material truncated: was ${REFERENCE_BYTES}B, now ${MAX_REFERENCE_BYTES}B."
+            echo "Reference material truncated: was ${REFERENCE_BYTES}B, now ${MAX_REFERENCE_BYTES}B (~$(( MAX_REFERENCE_BYTES / 4 )) tokens)."
           else
-            echo "Reference material assembled: ${REFERENCE_BYTES}B."
+            echo "Reference material assembled: ${REFERENCE_BYTES}B (~$(( REFERENCE_BYTES / 4 )) tokens)."
           fi
           REFERENCE_CONTENT="$(cat "$REFERENCE_FILE")"
           rm -f "$REFERENCE_FILE"


### PR DESCRIPTION
Fixes: `tokens_limit_reached: Request body too large for gpt-4o-mini model. Max size: 8000 tokens.`

### Root cause
GitHub Models free tier caps gpt-4o-mini at **8000 input tokens per request**. The Tier 2 reference block (full public headers + API cheatsheet) alone was ~30,000 tokens / 120KB — nearly 4× over the cap.

### Three budget changes

**1. Shrink the reference block**
- `MAX_REFERENCE_BYTES`: 120000 → **8000** (~2000 tokens). Overridable via `MAX_REFERENCE_BYTES_OVERRIDE` env for repos on plans with higher limits.
- `MAX_PER_FILE_BYTES`: new, default **3000**. Prevents one large header (MSALError.h is 19KB) from squeezing out all others.
- **Strip license/imports** from every `.h` via an awk pass: drops the 26-line MIT header and all `#import` / `#pragma` lines. Saves ~1 KB/header.

**2. Tighten PING-COPILOT thread caps**
Bring the question payload under ~3500 tokens worst-case:
```diff
- const MAX_THREAD_COMMENTS    = 20;
- const MAX_THREAD_CHARS       = 24000;
- const MAX_COMMENT_BODY_CHARS = 4000;
+ const MAX_THREAD_COMMENTS    = 8;
+ const MAX_THREAD_CHARS       = 6000;
+ const MAX_COMMENT_BODY_CHARS = 1500;
+ const MAX_ISSUE_BODY_CHARS   = 3000;
+ const MAX_TRIGGER_BODY_CHARS = 3000;
```

**3. Reorder `.github/ai-prompts/reference-files.txt`**
Most critical files first (usage examples, parameter builders, shared-device headers). Low-signal large headers (MSALError, MSALDefinitions, authority variants) go last — they'll be truncated when the 8KB cap kicks in, and their content is already summarized in `system-common.md`.

### Budget math (worst case, gpt-4o-mini 8000-token input cap)

| Section | Tokens |
|---|---|
| System prompt | ~1500 |
| Reference (capped) | ~2000 |
| Issue body + trigger (3KB + 3KB) | ~1500 |
| Thread (6KB capped) | ~1500 |
| Safety | ~1500 |
| **Total input** | **~8000** |

Completion is counted against a separate cap, so output isn't constrained.

### Local simulation

With the new caps, the reference block trims to:
- `.clinerules/03-MSAL-API-usage.md` (first 3KB — Interactive + Silent sections)
- `MSALSignoutParameters.h` (full, stripped)
- `MSALInteractiveTokenParameters.h` (partial, stripped)

That's the high-signal subset. Lower-priority files fall off the tail.

### To test

Post a PING-COPILOT on an existing issue or open a new issue. The Actions log should show:
```
Reference material truncated: was 41448B, now 8000B (~2000 tokens).
```
(or similar), and the Models API should respond 200 instead of 413/tokens_limit_reached.

### Tuning

- Raise the reference cap on larger-context models: set `MAX_REFERENCE_BYTES_OVERRIDE: "16000"` in the step's env.
- Add/remove files: edit `.github/ai-prompts/reference-files.txt`.
- Disable Tier 2 entirely: empty the manifest.

Same commit on origin PR branch (`kasong/ai-autoreply-ping-stop-copilot`, commit `b6387324d`) — the cap also helps origin if GitHub Models' cap on gpt-5 is similar.