### PR TITLE
[PATCH] [engg]: tolerate Models API outages and fix SIGPIPE abort in reference assembly

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -348,18 +348,40 @@ jobs:
           MAX_PER_FILE_BYTES="${MAX_PER_FILE_BYTES_OVERRIDE:-3000}"
 
           # Strip MIT license block + #import/#pragma lines from an Obj-C
-          # header. The license ends before the first #import / @-directive /
-          # NS_ASSUME_NONNULL_BEGIN. cat -s collapses repeated blank lines.
-          strip_hdr () {
-            awk '
-              BEGIN { skip_header = 1 }
+          # header, squeeze repeated blank lines, and cap output at N bytes.
+          # All in a single awk pass so there is no `| head -c` pipeline
+          # that could SIGPIPE under `set -o pipefail` (which was aborting
+          # the whole script with no visible error except "cat: write error:
+          # Broken pipe" at the very end).
+          strip_and_cap () {
+            awk -v max="$2" '
+              BEGIN { skip_header = 1; total = 0; last_blank = 0 }
               skip_header {
                 if (/^#import/ || /^NS_ASSUME_NONNULL_BEGIN/ || /^@/) { skip_header = 0 }
                 else { next }
               }
               /^#import/ || /^#pragma/ { next }
-              { print }
-            ' "$1" | cat -s
+              /^[[:space:]]*$/ {
+                if (last_blank) next
+                last_blank = 1
+                if (total + 1 > max) exit
+                print ""
+                total += 1
+                next
+              }
+              {
+                last_blank = 0
+                line_len = length($0) + 1
+                if (total + line_len > max) {
+                  # Truncate this line to remaining budget
+                  remaining = max - total - 1
+                  if (remaining > 0) print substr($0, 1, remaining)
+                  exit
+                }
+                print
+                total += line_len
+              }
+            ' "$1"
           }
 
           {
@@ -378,7 +400,7 @@ jobs:
                       ;;
                     *)
                       echo '```objc'
-                      strip_hdr "$path" | head -c "$MAX_PER_FILE_BYTES"
+                      strip_and_cap "$path" "$MAX_PER_FILE_BYTES"
                       echo '```'
                       ;;
                   esac
@@ -528,27 +550,43 @@ jobs:
               FALLBACK_USED="${GH_MODELS_FALLBACK_MODEL}"
             fi
 
-            # If the fallback also failed (or no fallback configured), bail.
+            # If the fallback also failed (or no fallback configured), emit a
+            # WARNING (not an error), leave steps.ai.outputs.text empty, and
+            # exit 0 so the overall workflow stays green. The "Post reply"
+            # step below is guarded on the text being non-empty, so it skips
+            # cleanly. This keeps forks/accounts without GitHub Models
+            # entitlement from turning the whole run red.
             if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
               if [[ -n "$FALLBACK_USED" ]]; then
-                echo "::error::Models API request failed with status $HTTP_CODE on both primary model '${GH_MODELS_MODEL}' and fallback model '${FALLBACK_USED}'. Check that at least one of these models is available on this repository's GitHub Models plan."
+                echo "::warning::Models API unavailable (HTTP $HTTP_CODE) on both primary model '${GH_MODELS_MODEL}' and fallback model '${FALLBACK_USED}'. Skipping AI reply for this run. Confirm that at least one of these models is available on this repository's GitHub Models plan."
               else
-                echo "::error::Models API request failed with status $HTTP_CODE after ${MAX_ATTEMPTS} attempt(s) using model '${GH_MODELS_MODEL}'. If this persists, try a different model (e.g. openai/gpt-4o-mini) by changing MODELS_MODEL in the workflow env."
+                echo "::warning::Models API unavailable (HTTP $HTTP_CODE) after ${MAX_ATTEMPTS} attempt(s) using model '${GH_MODELS_MODEL}'. Skipping AI reply for this run. If this persists, try a different model (e.g. openai/gpt-4o-mini) by changing MODELS_MODEL in the workflow env."
               fi
               echo "Response body (if any):"
               cat response.json 2>/dev/null || echo "(no response body written)"
-              exit 1
+              {
+                echo "text<<EOF"
+                echo ""
+                echo "EOF"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
             fi
 
             # Fallback succeeded — continue with response.json.
             echo "Fallback model '${FALLBACK_USED}' succeeded with HTTP ${HTTP_CODE}."
           fi
 
-          # Check for JSON error field
+          # Check for JSON error field. Same tolerance as above: warn,
+          # skip, stay green.
           if jq -e '.error' response.json >/dev/null 2>&1; then
-            echo "::error::API returned JSON error"
+            echo "::warning::Models API returned a JSON error payload. Skipping AI reply for this run."
             cat response.json
-            exit 1
+            {
+              echo "text<<EOF"
+              echo ""
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # Extract text
@@ -561,7 +599,9 @@ jobs:
 
 
       - name: Post reply
-        if: steps.gate.outputs.should == 'true'
+        # Skip when the AI step emitted no text (Models API was unavailable
+        # and the step chose to warn-and-skip instead of failing the job).
+        if: steps.gate.outputs.should == 'true' && steps.ai.outputs.text != ''
         uses: actions/github-script@v8
         env:
           DRY_RUN: ${{ env.DRY_RUN }}


### PR DESCRIPTION
Two root causes behind the failing `Generate AI reply` step at ref `707722f3`:

### 1. SIGPIPE under `set -o pipefail` (the actual cause of the silent abort)

The previous `strip_hdr` ended with `awk … | cat -s`, and the call site was `strip_hdr "$path" | head -c $MAX_PER_FILE_BYTES`. When `head` closed the pipe after reading its budget, the upstream `awk` + `cat` received `SIGPIPE`. With `set -o pipefail`, the pipeline's exit code was non-zero, and `set -e` aborted the script **before any Models API call was made**. The only visible symptom was the trailing `cat: write error: Broken pipe`.

**Fix**: fold stripping + blank-line squeeze + byte-cap into a single awk invocation (`strip_and_cap`). No pipe, no SIGPIPE.

```diff
- strip_hdr () {
-   awk '…' "$1" | cat -s
- }
- …
- strip_hdr "$path" | head -c "$MAX_PER_FILE_BYTES"
+ strip_and_cap () {
+   awk -v max="$2" '…handles stripping, squeezing, and capping in one pass…' "$1"
+ }
+ …
+ strip_and_cap "$path" "$MAX_PER_FILE_BYTES"
```

### 2. Models API hard-fail failed the whole job

On forks/accounts where the configured model isn't available (common — GitHub Models entitlement isn't on every plan), the API returns 4xx. The old code printed `::error::Models API request failed...` and `exit 1`, turning the whole workflow red even though nothing else is broken.

**Fix**: the bail path now emits a **warning** (not an error), writes an empty `text` output, and `exit 0`s. The `Post reply` step gains a guard:

```diff
- if: steps.gate.outputs.should == 'true'
+ if: steps.gate.outputs.should == 'true' && steps.ai.outputs.text != ''
```

So on Models outage: workflow stays **green**, a visible warning annotation appears, nothing is posted. Same treatment for the `jq -e '.error'` JSON-error branch.

### Net result

| Scenario | Before | After |
|---|---|---|
| Models available, call succeeds | post reply ✅ | post reply ✅ |
| Models returns 4xx (no entitlement) | ❌ job red, no reply | ⚠️ warning, no reply, job green |
| Models returns 5xx (transient) | retry 3× → ❌ | retry 3× → fallback → ⚠️ green |
| Reference gathering SIGPIPE | ❌ silent abort | N/A (no pipe) |

### To test

Open a new issue or post a PING-COPILOT. Behavior should be:
- If Models works: reply posted as before.
- If Models returns 4xx: Actions shows a yellow warning, no reply, workflow green.
- Log line like `::warning::Models API unavailable (HTTP 4xx)…` instead of red `::error::`.

Same commit on origin PR branch (`kasong/ai-autoreply-ping-stop-copilot`, commit `665b02466`). The SIGPIPE fix also applies there and is not fork-specific.