### PR TITLE
[Minor][Engg]: Add issue-aware (Tier 3) dynamic retrieval to AI auto-reply

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -352,6 +352,10 @@ jobs:
           REFERENCE_FILE="$(mktemp)"
           MAX_REFERENCE_BYTES="${MAX_REFERENCE_BYTES_OVERRIDE:-8000}"
           MAX_PER_FILE_BYTES="${MAX_PER_FILE_BYTES_OVERRIDE:-3000}"
+          # Tier 3 (dynamic) has its own smaller budget so issue-specific
+          # extracts never swallow the static curated set. Dynamic content is
+          # emitted BEFORE the static manifest so tail-truncation can't cut it.
+          MAX_DYNAMIC_BYTES="${MAX_DYNAMIC_BYTES_OVERRIDE:-3000}"
 
           # Strip MIT license block + #import/#pragma lines from an Obj-C
           # header, squeeze repeated blank lines, and cap output at N bytes.
@@ -390,9 +394,172 @@ jobs:
             ' "$1"
           }
 
+          # ---- Tier 3: issue-aware dynamic extracts ----
+          # Scan the issue text for (a) GitHub permalink URLs and (b) MSAL/MSID
+          # symbol names. Fetch the referenced files / locate matching public
+          # headers, and include the extracts ahead of the static manifest.
+          #
+          # Security: only URLs whose OWNER is in ALLOWED_OWNERS are fetched.
+          # This prevents an issue author from forcing the model to quote
+          # attacker-controlled content from arbitrary repositories.
+          #
+          # Budget: MAX_DYNAMIC_BYTES (default 3000) is enforced cumulatively
+          # across all dynamic extracts.
+          ALLOWED_OWNERS="${GITHUB_REPOSITORY_OWNER:-} AzureAD Azure microsoft microsoftgraph"
+          DYNAMIC_FILE="$(mktemp)"
+          DYNAMIC_USED=0
+
+          # Assemble the raw issue text (title + body + thread if present).
+          # Decoded here — the mode-specific branches below reuse these vars.
+          ISSUE_TITLE="$(jq -r '.' <<< "$ISSUE_TITLE_JSON" 2>/dev/null || true)"
+          ISSUE_BODY="$(jq -r '.'  <<< "$ISSUE_BODY_JSON" 2>/dev/null || true)"
+          ISSUE_TEXT_ALL="${ISSUE_TITLE}
+          ${ISSUE_BODY}"
+          if [[ "${MODE:-initial}" == "ping_copilot" && -f prompt_input.json ]]; then
+            THREAD_TEXT="$(jq -r '
+              ((.thread // []) | map(.body) | join("\n\n"))
+              + "\n\n" + (.trigger.body // "")
+            ' prompt_input.json 2>/dev/null || true)"
+            ISSUE_TEXT_ALL+="
+          ${THREAD_TEXT}"
+          fi
+
+          # Helper: append a block to DYNAMIC_FILE if it fits under the cap.
+          # Args: header, content (from stdin).
+          dyn_append () {
+            local header="$1"
+            local block
+            block="$(cat)"
+            local block_bytes
+            block_bytes=$(( ${#header} + ${#block} + 3 ))
+            if (( DYNAMIC_USED + block_bytes > MAX_DYNAMIC_BYTES )); then
+              return 0
+            fi
+            {
+              echo "$header"
+              echo ""
+              echo "$block"
+              echo ""
+            } >> "$DYNAMIC_FILE"
+            DYNAMIC_USED=$(( DYNAMIC_USED + block_bytes ))
+          }
+
+          # (a) Extract up to 3 unique github.com/OWNER/REPO/blob permalinks.
+          mapfile -t BLOB_URLS < <(
+            grep -oE 'https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/blob/[^[:space:]<>)"]+' \
+              <<< "$ISSUE_TEXT_ALL" 2>/dev/null | sort -u | head -n 3 || true
+          )
+          for url in "${BLOB_URLS[@]:-}"; do
+            [[ -z "$url" ]] && continue
+            # Parse OWNER/REPO/REF/PATH[#Lstart[-Lend]]
+            stripped="${url#https://github.com/}"
+            owner="${stripped%%/*}"; rest="${stripped#*/}"
+            repo="${rest%%/*}";      rest="${rest#*/}"
+            # rest now starts with "blob/REF/PATH"
+            rest="${rest#blob/}"
+            ref="${rest%%/*}";       path_and_frag="${rest#*/}"
+            path="${path_and_frag%%#*}"
+            frag=""
+            if [[ "$path_and_frag" == *"#"* ]]; then
+              frag="${path_and_frag#*#}"
+            fi
+            # Owner allowlist check
+            allowed=0
+            for ok in $ALLOWED_OWNERS; do
+              if [[ "$owner" == "$ok" ]]; then allowed=1; break; fi
+            done
+            if [[ $allowed -eq 0 ]]; then
+              echo "::warning::Skipping permalink from disallowed owner '$owner': $url"
+              continue
+            fi
+            raw_url="https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}"
+            tmp_content="$(mktemp)"
+            if ! curl -sSL --max-time 20 -o "$tmp_content" "$raw_url"; then
+              echo "::warning::Failed to fetch $raw_url"
+              rm -f "$tmp_content"; continue
+            fi
+            # Parse line range from fragment: L123 or L123-L145 (also L123-145)
+            start_line=""; end_line=""
+            if [[ "$frag" =~ ^L([0-9]+)(-L?([0-9]+))?$ ]]; then
+              start_line="${BASH_REMATCH[1]}"
+              end_line="${BASH_REMATCH[3]:-}"
+            fi
+            header="## Referenced file: ${owner}/${repo} ${path}${frag:+ #$frag}"
+            if [[ -n "$start_line" ]]; then
+              # Include 10 lines of context before the range and 5 after, capped
+              s=$(( start_line > 10 ? start_line - 10 : 1 ))
+              e="${end_line:-$start_line}"
+              e=$(( e + 5 ))
+              snippet="$(awk -v s="$s" -v e="$e" 'NR>=s && NR<=e { print NR": "$0 }' "$tmp_content")"
+            else
+              # No line hint — include the first N bytes capped by strip_and_cap
+              # for .h files, otherwise raw head.
+              case "$path" in
+                *.h|*.m|*.mm) snippet="$(strip_and_cap "$tmp_content" 1500)" ;;
+                *)            snippet="$(head -c 1500 "$tmp_content")" ;;
+              esac
+            fi
+            rm -f "$tmp_content"
+            case "$path" in
+              *.h|*.m|*.mm|*.c|*.cpp) lang='```objc' ;;
+              *.swift)                lang='```swift' ;;
+              *.py)                   lang='```python' ;;
+              *.md|*.txt)             lang='```' ;;
+              *)                      lang='```' ;;
+            esac
+            dyn_append "$header" <<DYN_EOF
+          $lang
+          $snippet
+          \`\`\`
+          DYN_EOF
+          done
+
+          # (b) Extract MSAL/MSID/ADB symbol names mentioned in the issue text.
+          # Match tokens of the form MSAL*, MSID*, ADB*, each >=6 chars, take
+          # up to 5 most-frequent. Resolve each against local public headers.
+          mapfile -t SYMBOLS < <(
+            grep -oE '\b(MSAL|MSID|ADB)[A-Z][A-Za-z0-9_]{3,}' <<< "$ISSUE_TEXT_ALL" 2>/dev/null \
+              | sort | uniq -c | sort -rn | awk '{print $2}' | head -n 5 || true
+          )
+          for sym in "${SYMBOLS[@]:-}"; do
+            [[ -z "$sym" ]] && continue
+            # Resolve: try MSAL/src/public first, then IdentityCore public dirs
+            match=""
+            for candidate in \
+              "MSAL/src/public/${sym}.h" \
+              "MSAL/src/public/${sym}+"*.h \
+              "MSAL/IdentityCore/IdentityCore/src/"**"/public/${sym}.h"; do
+              # Use compgen to expand globs without erroring when no match
+              for f in $(compgen -G "$candidate" 2>/dev/null || true); do
+                if [[ -f "$f" ]]; then match="$f"; break 2; fi
+              done
+            done
+            if [[ -z "$match" ]]; then
+              # Already covered by static manifest? skip silently.
+              continue
+            fi
+            dyn_append "## Issue-mentioned symbol \`${sym}\` — ${match}" <<DYN_EOF
+          \`\`\`objc
+          $(strip_and_cap "$match" 1500)
+          \`\`\`
+          DYN_EOF
+          done
+
+          if [[ $DYNAMIC_USED -gt 0 ]]; then
+            echo "Tier 3 dynamic extracts: ${DYNAMIC_USED}B across $(( ${#BLOB_URLS[@]:-0} + ${#SYMBOLS[@]:-0} )) candidate(s)."
+          fi
+
           {
             echo "The following are extracts from this repository. When answering, cite specific APIs, parameter names, flag defaults, and file paths from these extracts rather than generic OAuth/OIDC knowledge. If the answer is not covered here, say so."
             echo ""
+            if [[ -s "$DYNAMIC_FILE" ]]; then
+              echo "### Issue-specific extracts"
+              echo ""
+              cat "$DYNAMIC_FILE"
+              echo ""
+              echo "### Curated repository extracts"
+              echo ""
+            fi
             if [[ -f "$REFERENCE_MANIFEST" ]]; then
               while IFS= read -r path || [[ -n "$path" ]]; do
                 # Skip blank lines and comments
@@ -419,6 +586,7 @@ jobs:
               echo "::warning::Reference manifest $REFERENCE_MANIFEST not found; proceeding without Tier 2 grounding."
             fi
           } > "$REFERENCE_FILE"
+          rm -f "$DYNAMIC_FILE"
 
           REFERENCE_BYTES=$(wc -c < "$REFERENCE_FILE")
           if (( REFERENCE_BYTES > MAX_REFERENCE_BYTES )); then

--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -474,8 +474,10 @@ jobs:
             fi
             raw_url="https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}"
             tmp_content="$(mktemp)"
-            if ! curl -sSL --max-time 20 -o "$tmp_content" "$raw_url"; then
-              echo "::warning::Failed to fetch $raw_url"
+            http_code="$(curl -sSL --max-time 20 -w '%{http_code}' -o "$tmp_content" "$raw_url")"
+            curl_status=$?
+            if [[ $curl_status -ne 0 || "$http_code" != "200" ]]; then
+              echo "::warning::Failed to fetch $raw_url (curl exit: $curl_status, HTTP status: ${http_code:-unknown})"
               rm -f "$tmp_content"; continue
             fi
             # Parse line range from fragment: L123 or L123-L145 (also L123-145)
@@ -507,11 +509,11 @@ jobs:
               *.md|*.txt)             lang='```' ;;
               *)                      lang='```' ;;
             esac
-            dyn_append "$header" <<DYN_EOF
-          $lang
-          $snippet
-          \`\`\`
-          DYN_EOF
+            {
+              printf '%s\n' "$lang"
+              printf '%s\n' "$snippet"
+              printf '```\n'
+            } | dyn_append "$header"
           done
 
           # (b) Extract MSAL/MSID/ADB symbol names mentioned in the issue text.
@@ -525,32 +527,38 @@ jobs:
             [[ -z "$sym" ]] && continue
             # Resolve: try MSAL/src/public first, then IdentityCore public dirs
             match=""
+            # Enable globstar for ** matching in IdentityCore submodule paths
+            shopt -s globstar 2>/dev/null || true
             for candidate in \
               "MSAL/src/public/${sym}.h" \
-              "MSAL/src/public/${sym}+"*.h \
-              "MSAL/IdentityCore/IdentityCore/src/"**"/public/${sym}.h"; do
-              # Use compgen to expand globs without erroring when no match
+              "MSAL/src/public/${sym}+"*.h; do
               for f in $(compgen -G "$candidate" 2>/dev/null || true); do
                 if [[ -f "$f" ]]; then match="$f"; break 2; fi
               done
             done
+            # Fallback: search IdentityCore submodule with find (works without globstar)
+            if [[ -z "$match" && -d "MSAL/IdentityCore" ]]; then
+              match="$(find "MSAL/IdentityCore" -path "*/public/${sym}.h" -type f 2>/dev/null | head -n 1 || true)"
+            fi
             if [[ -z "$match" ]]; then
               # Already covered by static manifest? skip silently.
               continue
             fi
-            dyn_append "## Issue-mentioned symbol \`${sym}\` — ${match}" <<DYN_EOF
-          \`\`\`objc
-          $(strip_and_cap "$match" 1500)
-          \`\`\`
-          DYN_EOF
+            {
+              printf '```objc\n'
+              strip_and_cap "$match" 1500
+              printf '```\n'
+            } | dyn_append "## Issue-mentioned symbol \`${sym}\` — ${match}"
           done
 
           if [[ $DYNAMIC_USED -gt 0 ]]; then
-            echo "Tier 3 dynamic extracts: ${DYNAMIC_USED}B across $(( ${#BLOB_URLS[@]:-0} + ${#SYMBOLS[@]:-0} )) candidate(s)."
+            blob_count=${#BLOB_URLS[@]}
+            sym_count=${#SYMBOLS[@]}
+            echo "Tier 3 dynamic extracts: ${DYNAMIC_USED}B across $(( blob_count + sym_count )) candidate(s)."
           fi
 
           {
-            echo "The following are extracts from this repository. When answering, cite specific APIs, parameter names, flag defaults, and file paths from these extracts rather than generic OAuth/OIDC knowledge. If the answer is not covered here, say so."
+            echo "The following are extracts from this repository and, where explicitly allowlisted by this workflow, from other GitHub owners/repos. Use each snippet header as the source of truth for provenance. When answering, cite specific APIs, parameter names, flag defaults, and file paths from these extracts rather than generic OAuth/OIDC knowledge. If the answer is not covered here, say so."
             echo ""
             if [[ -s "$DYNAMIC_FILE" ]]; then
               echo "### Issue-specific extracts"

--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -527,7 +527,7 @@ jobs:
             [[ -z "$sym" ]] && continue
             # Resolve: try MSAL/src/public first, then IdentityCore public dirs
             match=""
-            # Enable globstar for ** matching in IdentityCore submodule paths
+            # Enable globstar for ** matching; restore afterwards to avoid side effects
             shopt -s globstar 2>/dev/null || true
             for candidate in \
               "MSAL/src/public/${sym}.h" \
@@ -536,6 +536,7 @@ jobs:
                 if [[ -f "$f" ]]; then match="$f"; break 2; fi
               done
             done
+            shopt -u globstar 2>/dev/null || true
             # Fallback: search IdentityCore submodule with find (works without globstar)
             if [[ -z "$match" && -d "MSAL/IdentityCore" ]]; then
               match="$(find "MSAL/IdentityCore" -path "*/public/${sym}.h" -type f 2>/dev/null | head -n 1 || true)"


### PR DESCRIPTION
## Summary

Adds a dynamic, issue-aware retrieval pass (Tier 3) to the AI auto-reply workflow so the model can ground answers in actual MSAL source rather than training-data residue.

## Why

The workflow already had static Tier 2 grounding (17 curated public headers via \`reference-files.txt\`), but when users asked about MSAL internals (e.g. pasted a permalink, named a specific \`MSAL*\`/\`MSID*\` class), the model had no way to pull that specific file into context. It fell back to generic OAuth/OIDC knowledge, often incorrectly.

## What the Tier 3 pass does

Runs **before** the static manifest and scans the issue title, body, and (for \`PING-COPILOT\` follow-ups) the full thread for:

1. **GitHub permalink URLs** — \`github.com/OWNER/REPO/blob/...\`
   - Up to 3 unique URLs per issue
   - Owner allowlist (current owner + \`AzureAD\` / \`Azure\` / \`microsoft\` / \`microsoftgraph\`) to prevent an attacker-authored issue from forcing the model to quote arbitrary external content
   - Fetches via \`raw.githubusercontent.com\` (no auth required for public repos)
   - Extracts the referenced line range (10 lines before, 5 after) for \`#L123\` or \`#L123-L145\` fragments; otherwise first 1500 bytes with Obj-C boilerplate stripped
2. **\`MSAL\` / \`MSID\` / \`ADB\` symbol names** — e.g. \`MSALPublicClientApplication\`, \`MSIDTokenCacheAccessor\`
   - Top 5 most-frequent symbols mentioned in the issue
   - Resolved against \`MSAL/src/public/*.h\` and IdentityCore public header paths
   - Included via existing \`strip_and_cap\` helper

Dynamic extracts are emitted **before** the static manifest in the reference block so the tail-truncation pass can't drop them, and they live under a **separate** byte budget (\`MAX_DYNAMIC_BYTES\`, default 3000) so they never displace the curated set.

## Safety

- Owner allowlist (see above) prevents arbitrary-repo content injection.
- Permalink fetches have a 20s \`curl --max-time\` and fail gracefully (log \`::warning::\` and skip) rather than aborting the workflow.
- All extractions respect the cumulative byte budget; if the budget is exhausted, later candidates are silently dropped.
- No new secrets, no new permissions, no changes to the Models API call or fallback model-list behavior.

## What doesn't change

- Static Tier 2 manifest (\`reference-files.txt\`) is untouched.
- Model fallback chain (\`gpt-5\` → \`gpt-4.1\` → \`gpt-4o\` → \`gpt-4o-mini\`) is untouched.
- System prompt files (\`system-common.md\`, \`system-task-*.md\`) are untouched.

## Test plan

- [ ] File an issue on the fork that pastes a GitHub permalink to an MSAL public header — verify the auto-reply cites the specific APIs from that file.
- [ ] File an issue that mentions a specific MSAL class (e.g. "how does \`MSALInteractiveTokenParameters\` handle \`webviewParameters\`") — verify the reply references the actual header content, not generic guesses.
- [ ] File an issue with a permalink whose owner is NOT in the allowlist (e.g. a random user's fork URL) — verify it emits a \`::warning::Skipping permalink from disallowed owner\` and does not fetch.
- [ ] File an issue with no permalinks and no MSAL symbols — verify the workflow falls back cleanly to Tier 2 behavior with no dynamic section in the prompt.
- [ ] File a \`PING-COPILOT:\` follow-up on an existing thread — verify thread text is also scanned for URLs/symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)